### PR TITLE
Set default subscription option to start from beginning

### DIFF
--- a/pkg/nats/nats_test.go
+++ b/pkg/nats/nats_test.go
@@ -74,14 +74,12 @@ func TestNew_Start(t *testing.T) {
 	var msg []byte
 	exit := make(chan struct{})
 
-	sub, err := sc.QueueSubscribe(cfg.Nats.Inbox, "foo", func(m *stan.Msg) {
+	_, err = sc.QueueSubscribe(cfg.Nats.Inbox, "foo", func(m *stan.Msg) {
 		msg = m.Data
 		m.Ack()
 		exit <- struct{}{}
-	}, stan.SetManualAckMode(), stan.DurableName("foo"), stan.StartWithLastReceived())
+	}, stan.SetManualAckMode(), stan.DurableName("foo"), stan.DeliverAllAvailable())
 	assert.NoError(t, err)
-
-	defer sub.Unsubscribe()
 
 	select {
 	case <-exit:

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -371,13 +371,12 @@ func (p *Plugin) subInboxFunc(sub chan<- Event, funcs ...filters.FilterFunc) fun
 			if event != nil {
 				sub <- event
 			}
-		}, stan.DurableName(p.runtime.Name), stan.StartWithLastReceived())
+		}, stan.DurableName(p.runtime.Name), stan.DeliverAllAvailable())
 		if err != nil {
 			return err
 		}
 
 		<-p.ctx.Done()
-		s.Unsubscribe()
 		s.Close()
 		// close channel
 		close(sub)
@@ -417,13 +416,12 @@ func (p *Plugin) subOutboxFunc(sub chan<- Event, funcs ...filters.FilterFunc) fu
 			if event != nil {
 				sub <- event
 			}
-		}, stan.DurableName(p.runtime.Name), stan.StartWithLastReceived())
+		}, stan.DurableName(p.runtime.Name), stan.DeliverAllAvailable())
 		if err != nil {
 			return err
 		}
 
 		<-p.ctx.Done()
-		s.Unsubscribe()
 		s.Close()
 
 		// close channel

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -49,7 +49,7 @@ func TestPublishInbox(t *testing.T) {
 			assert.NoError(err)
 
 			sub <- botMessage
-		}, stan.DurableName(env.Name), stan.StartWithLastReceived())
+		}, stan.DurableName(env.Name), stan.DeliverAllAvailable())
 		assert.NoError(err)
 
 		defer s.Close()
@@ -137,7 +137,7 @@ func TestPublishOutbox(t *testing.T) {
 			assert.NoError(err)
 
 			sub <- botMessage
-		}, stan.DurableName(env.Name), stan.StartWithLastReceived())
+		}, stan.DurableName(env.Name), stan.DeliverAllAvailable())
 		assert.NoError(err)
 
 		defer s.Close()

--- a/pkg/testing/autobot.go
+++ b/pkg/testing/autobot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/andersnormal/pkg/server"
 )
 
+// WithAutobot is a test helper, spins up a nats server
 func WithAutobot(t *testing.T, env *runtime.Environment, f func(*testing.T)) {
 	cfg := config.New()
 	cfg.Verbose = true
@@ -42,5 +43,6 @@ func WithAutobot(t *testing.T, env *runtime.Environment, f func(*testing.T)) {
 	// wait for server to close ...
 	_ = s.Wait()
 
+	// nats seems to take some time to teardown
 	<-time.After(3 * time.Second)
 }


### PR DESCRIPTION
Unsubscribing removes the offset from the server for a durable group!

We can idempotently subscribe to a queue though, so no worries there. Can do some more playing around with [this test](https://github.com/nats-io/stan.go/blob/718b5a38cc59a2a181b7449467046ecf2092d599/stan_test.go#L391-L443) to understand the behaviour there a bit better. 

Also, `DeliverAllAvailable` is only a default if there is no offset stored on the server for this consumer group for a specific subject - just like Kafka. This should make the tests pass consistently 🤞 